### PR TITLE
memory.py: fix indexing for read_modes transform

### DIFF
--- a/dnc/memory.py
+++ b/dnc/memory.py
@@ -254,7 +254,7 @@ class Memory(nn.Module):
       # write gate (b * 1)
       write_gate = F.sigmoid(ξ[:, r * w + 2 * r + 3 * w + 2].contiguous()).unsqueeze(1).view(b, 1)
       # read modes (b * 3*r)
-      read_modes = σ(ξ[:, r * w + 2 * r + 3 * w + 2: r * w + 5 * r + 3 * w + 2].contiguous().view(b, r, 3), 1)
+      read_modes = σ(ξ[:, r * w + 2 * r + 3 * w + 3: r * w + 5 * r + 3 * w + 3].contiguous().view(b, r, 3), 1)
 
     hidden = self.write(write_key, write_vector, erase_vector, free_gates,
                         read_strengths, write_strength, write_gate, allocation_gate, hidden)


### PR DESCRIPTION
The read_modes vector overlaps with write_gate, and should be shifted by one element.